### PR TITLE
Feat/archive description

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,8 +45,8 @@ container.bind<inversify.interfaces.Newable<GlacierMultipartUpload>>(TYPES.Glaci
   "ArchiveId": "{{ returned archive id }}"
 }
 ```
-1. Run `glacier initiate-job --account-id - --vault-name {{ vault name }} --job-parameters file://{{ saved job param file }}`.
+1. Run `aws glacier initiate-job --account-id - --vault-name {{ vault name }} --job-parameters file://{{ saved job param file }}`.
 returns job id
-1. Poll with `glacier describe-job --account-id - --vault-name {{ vault name }} --job-id {{ returned job id }}`
+1. Poll with `aws glacier describe-job --account-id - --vault-name {{ vault name }} --job-id {{ returned job id }}`
 returns complete status
-1. When complete, retrieve: `glacier get-job-output --account-id - --vault-name {{ vault name }} --job-id {{ job id }} <save location>`
+1. When complete, retrieve: `aws glacier get-job-output --account-id - --vault-name {{ vault name }} --job-id {{ job id }} <save location>`

--- a/readme.md
+++ b/readme.md
@@ -5,17 +5,13 @@ Upload files to Amazon S3 Glacier
 
 ### Business logic
 * [x] Enforce a max file size for single file upload
-* [ ] Accept user-provided AWS credentials
 * [x] Disallow uploading an empty file
 * [x] Set up queue mechanism (async.queue)
 * [x] Retry failed uploads
 * [x] Make sure the (optional) archiveId property returned by Glacier uploads is not undefined
-* [ ] Accept archive description
-* [ ] New or existing Glacier vault (create if not exist)
 * [ ] Download archive
 * [ ] Store uploaded archives in db
 * [ ] Download notifications
-* [ ] Logger
 
 ### Optimizations
 * [ ] Create full-file tree hash from stream instead of buffer (better for large files)
@@ -32,7 +28,6 @@ container.bind<inversify.interfaces.Newable<GlacierMultipartUpload>>(TYPES.Glaci
 
 ### Deliverable
 * [ ] Set up build pipeline
-* [ ] Create command line app
 * [ ] cross-compile
 * [ ] publish as npm package
 

--- a/src/app/config/config.ts
+++ b/src/app/config/config.ts
@@ -2,6 +2,7 @@ export interface AppConfig {
   chunkSize: number
   concurrency: number
   vaultName: string
+  description?: string
 }
 
 export type ConfigInput = Partial<Omit<AppConfig, "chunkSize"> & {
@@ -17,12 +18,19 @@ export class Config implements AppConfig {
   public readonly chunkSize: number
   public readonly concurrency: number
   public readonly vaultName: string
+  public readonly description?: string
   private readonly maxChunkSize = this.defaultChunkSize * 1024 * 4
 
   public constructor(config: ConfigInput = {}) {
     this.chunkSize = this.getChunkSize(config.fileSizeInMB)
     this.concurrency = config.concurrency || Config.concurrency
     this.vaultName = config.vaultName || Config.vaultName
+
+    const { description } = config
+
+    if (description && description.length) {
+      this.description = description
+    }
   }
 
   /**

--- a/test/unit/app/config/config.test.ts
+++ b/test/unit/app/config/config.test.ts
@@ -35,4 +35,18 @@ describe("Config", () => {
     const config2 = new Config({ concurrency: 7 })
     expect(config2.concurrency).toBe(7)
   })
+
+  it("will set a description for the archive if one is provided", () => {
+    const description = "archive description"
+    const config = new Config({ description })
+
+    expect(config.description).toBe(description)
+  })
+
+  it("will not set description for the archive if an empty string is provided", () => {
+    const description = ""
+    const config = new Config({ description })
+
+    expect(config.description).toBeUndefined()
+  })
 })


### PR DESCRIPTION
Allow passing `description` to AppConfig. This becomes the description of the archive that is uploaded. Resolves #3 